### PR TITLE
Fetch data files uploaded as Github releases

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,12 +30,14 @@ requirements:
     - {{ compiler('clang') }}          # [win]
     - cmake
     - make                             # [unix]
+    - curl
 
 test:
   requires:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
     - cmake
+    - curl
   source_files:
     - test/test_binary
   commands:

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,41 +1,44 @@
+:: *********************************************************** 
+::
+:: This script downloads the raw data files distributed manually as release on 
+:: the tudat-resources Github repository and places them in $HOME/.tudat/resource
+:: directory on the host machine. 
+
+:: This script is written precisely to download the data files distributed 
+:: directly as GitHub releases, because in the future, Github would block pushing
+:: data files > 100 MB to the repository, so they need to be distributed as
+:: releases-only. 
+:: In order for this script to function correctly, upload only a single zip file
+:: with the name <resource> containing all the sub directories with the data 
+:: files, i.e., the resource/ in master, or the data/ in develop.
+::
+:: The script is run automatically by conda as the last step in the installation
+:: process of the conda package tudat-resources on the host machine.
+:: 
+:: **********************************************************
+
+
 @REM set hidden path for tudat
 set HIDDEN_PATH=%HOMEDRIVE%/%HOMEPATH%/.tudat
-set TEMP_PATH=./tmp/
+
+@REM Set package version
+set PKG_VERSION=v1.2.1.dev5
 
 @REM Set resource git URL and REV
-set RESOURCE_GIT_URL="https://github.com/tudat-team/tudat-resources.git"
-
-@REM Read whole file of git_rev.txt file into variable
-set RESOURCE_GIT_REV="c1306808bc98614b717599627e7b22e0a20054eb"
-	
-@REM Debugging 42
-echo "RESOURCE_GIT_REV: %RESOURCE_GIT_REV%"
-echo "RECIPE_DIR      : %RECIPLE_DIR%"
-dir /b /a-d
+set RESOURCE_GITHUB_URL="https://github.com/niketagrawal/tudat-resources/releases/download/%PKG_VERSION%/resource.tar.gz"
 
 @REM Create destination hidden folder
 if not exist "%HIDDEN_PATH%" mkdir "%HIDDEN_PATH%"
 if errorlevel 1 exit 1
 
-@REM Create destination resource folder
-if not exist "%HIDDEN_PATH%/resource" mkdir "%HIDDEN_PATH%/resource"
-if errorlevel 1 exit 1
+@REM Go to target location
+cd %HIDDEN_PATH%
 
-@REM Create temp  folder
-if not exist "%TEMP_PATH%" mkdir "%TEMP_PATH%"
-if errorlevel 1 exit 1
-cd "%TEMP_PATH%"
+@REM Fetch the Github release containing the raw data files
+curl -JLO %RESOURCE_GITHUB_URL%
 
-@REM We don't want the main branch, so we initiate git repo
-@REM and checkout the target sha1
-git init
-git remote add -f origin "%RESOURCE_GIT_URL%"
-git fetch origin "%RESOURCE_GIT_REV%"
-git reset --hard FETCH_HEAD
+@REM Unpack the content and place it in resource/
+tar -xvf resource.tar.gz
 
-@REM attempt to copy resources to home folder
-xcopy "/resource" "%HIDDEN_PATH%/resource" /s /e /y
-if errorlevel 1 exit 1
-
-@REM Delete temp folder
-rmdir /s /q "%TEMP_PATH%"
+@REM [Optional] Delete the original tar file
+del .\resource.tar.gz

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -17,9 +17,15 @@
 :: 
 :: **********************************************************
 
+@REM DEBUG
+echo "HOMEDRIVE is %HOMEDRIVE%"
+echo "HOMEPATH is %HOMEPATH%"
 
 @REM set hidden path for tudat
 set HIDDEN_PATH=%HOMEDRIVE%/%HOMEPATH%/.tudat
+
+@REM DEBUG
+echo "HIDDEN_PATH is %HIDDEN_PATH%"
 
 @REM Set package version
 set PKG_VERSION=v1.2.1.dev5
@@ -31,14 +37,24 @@ set RESOURCE_GITHUB_URL="https://github.com/niketagrawal/tudat-resources/release
 if not exist "%HIDDEN_PATH%" mkdir "%HIDDEN_PATH%"
 if errorlevel 1 exit 1
 
+@REM DEBUG 
+if exist "%HIDDEN_PATH%" echo "Directory %HIDDEN_PATH% exists"
+
 @REM Go to target location
-cd %HIDDEN_PATH%
+cd /d %HIDDEN_PATH%
+
+@REM DEBUG
+echo "Current directory is %CD%"
 
 @REM Fetch the Github release containing the raw data files
 curl -JLO %RESOURCE_GITHUB_URL%
 
 @REM Unpack the content and place it in resource/
 tar -xvf resource.tar.gz
+
+@REM DEBUG: Check if directory %HIDDEN_PATH%/.tudat/resource exists 
+set RESOURCE_PATH=%HIDDEN_PATH%/resource
+if exist "%RESOURCE_PATH%" echo "Directory %RESOURCE_PATH% exists"
 
 @REM [Optional] Delete the original tar file
 del .\resource.tar.gz

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,33 +1,44 @@
 #!/bin/bash
-RESOURCE_GIT_URL="https://github.com/tudat-team/tudat-resources.git"
-RESOURCE_GIT_REV="c1306808bc98614b717599627e7b22e0a20054eb"
-# set hidden path
-HIDDEN_PATH=$HOME/.tudat
-TARGET_PATH="$HIDDEN_PATH"/resource/
-TEMP_PATH=./tmp/
 
-# create destination hidden folder & resource folder
-mkdir -p $TARGET_PATH
-mkdir -p $TEMP_PATH
+# *********************************************************** 
+#
+# This script downloads the raw data files distributed manually as release on 
+# the tudat-resources Github repository and places them in $HOME/.tudat/resource
+# directory on the host machine. 
 
-# Debugging 101 
-echo "INSIDE_RECIPE_DIR: $(ls ${RECIPE_DIR})"
-echo "RESOURCE_GIT_REV ${RESOURCE_GIT_REV}"
-echo "RECIPE_DIR ${RECIPE_DIR}"
+# This script is written precisely to download the data files distributed 
+# directly as GitHub releases, because in the future, Github would block pushing
+# data files > 100 MB to the repository, so they need to be distributed as
+# releases-only. 
+# In order for this script to function correctly, upload only a single zip file
+# with the name <resource> containing all the sub directories with the data 
+# files, i.e., the resource/ in master, or the data/ in develop.
+#
+# The script is run automatically by conda as the last step in the installation
+# process of the conda package tudat-resources on the host machine.
+# 
+# **********************************************************
 
-cd $TEMP_PATH
 
-# fetch get only the target sha1
-git init
-git remote add origin $RESOURCE_GIT_URL
-git fetch origin ${RESOURCE_GIT_REV}
-git reset --hard FETCH_HEAD
+PKG_VERSION=v1.2.1.dev5
+RESOURCE_GITHUB_URL="https://github.com/niketagrawal/tudat-resources/releases/download/$PKG_VERSION/resource.tar.gz"
 
-# copy the resource subdirectory to
-cp -a ./resource/. $TARGET_PATH
+# Target location on the host machine where the data files will be downloaded
+TARGET_LOCATION=$HOME/.tudat/
 
-# go back 2 levels
-cd ../
+# Remove target directory if already present
+# Add code
 
-# delete the tmp directory
-rm -rf $TEMP_PATH
+# Create the target directory on the host machine
+mkdir -p $TARGET_LOCATION
+
+cd $TARGET_LOCATION
+
+# Fetch the Github release containing the raw data files
+curl -JLO $RESOURCE_GITHUB_URL
+
+# Unpack the content and place it in resource/
+tar -xvf resource.tar.gz
+
+# [Optional] Delete the original tar file
+rm -rf resource.tar.gz


### PR DESCRIPTION
- Addresses issue #1

- Post-link script downloads the raw data files distributed manually as release on the tudat-resources Github repository and places them in $HOME/.tudat/resource directory on the host machine. 

- The post-link scripts is written precisely to download the data files distributed directly as GitHub releases, because in the future, Github would block pushing data files > 100 MB to the repository, so they need to be distributed as releases-only. 

- In order for this script to function correctly, upload only a single zip file with the name `resource` containing all the sub directories with the data  files, i.e., the contents of the directory `resource/` in master, or `data/` in develop.

