### PR TITLE
Feature/installPyTrk234

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,24 @@ requirements:
     # tools (GNU make, Autotool, CMake) and compilers (real cross, pseudo-cross,
     # or native when not cross-compiling), and any source pre-processors.
     - cmake
-    - make # [unix]
+    - make                             # [unix]
+    - curl
+  run:
+    - python
+    - pip
+    - git
+
+test:
+  requires:
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+    - cmake
+    - curl
+  source_files:
+    - test/test_binary
+  commands:
+    - cd ./test/test_binary
+    - bash run_binary_test.sh
 
 about:
   home: http://tudat.tudelft.nl/

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -37,5 +37,25 @@ git reset --hard FETCH_HEAD
 xcopy "/resource" "%HIDDEN_PATH%/resource" /s /e /y
 if errorlevel 1 exit 1
 
-@REM Delete temp folder
-rmdir /s /q "%TEMP_PATH%"
+@REM Unpack the content and place it in resource/
+tar -xvf resource.tar.gz
+
+@REM DEBUG: Check if directory %HIDDEN_PATH%/.tudat/resource exists 
+set RESOURCE_PATH=%HIDDEN_PATH%/resource
+if exist "%RESOURCE_PATH%" echo "Directory %RESOURCE_PATH% exists"
+
+@REM [Optional] Delete the original tar file
+del .\resource.tar.gz
+
+@REM Define target directory in Conda environment
+set "TARGET_DIR=%CONDA_PREFIX%\share\external-repo"
+
+@REM Create directory if it doesn't exist
+if not exist "%TARGET_DIR%" mkdir "%TARGET_DIR%"
+cd /d "%TARGET_DIR%"
+
+@REM Clone repository using git
+git clone https://github.com/NASA-PDS/PyTrk234.git .
+
+@REM Install the cloned repository with pip
+pip install .

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -32,3 +32,22 @@ cd ../
 # delete the tmp directory
 rm -rf $TEMP_PATH
 
+# Fetch the Github release containing the raw data files
+curl -JLO $RESOURCE_GITHUB_URL
+
+# Unpack the content and place it in resource/
+tar -xvf resource.tar.gz
+
+# [Optional] Delete the original tar file
+rm -rf resource.tar.gz
+
+# Directory within the Conda environment for external repository
+TARGET_DIR="$CONDA_PREFIX/share/external-repo"
+mkdir -p "$TARGET_DIR"
+cd "$TARGET_DIR"
+
+# Clone the repository
+git clone https://github.com/NASA-PDS/PyTrk234.git .
+
+# Install the cloned repository into the environment
+pip install .


### PR DESCRIPTION
Add post-link scripts for Windows and Linux to the recipe for the installation of the python package pyTrk234 (https://github.com/NASA-PDS/PyTrk234#).
